### PR TITLE
Adds sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Docs:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+custom:  https://sobe.ru/na/teamlead101


### PR DESCRIPTION
I've noticed that you have "donations" sections. It might be a good idea to add `FUNDING.yml`.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

It should render a button like this after merge:
<img width="127" alt="Снимок экрана 2021-09-20 в 22 55 42" src="https://user-images.githubusercontent.com/4660275/134066670-ce20c03d-9738-4046-8cdf-ad2a42627d69.png">

